### PR TITLE
Add Swift Package Manager support for iOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 pubspec.lock
 
 build/
+.build/
+.swiftpm/
 # Compiled class file
 *.class
 

--- a/ios/flutter_jailbreak_detection_plus/Package.swift
+++ b/ios/flutter_jailbreak_detection_plus/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version: 5.9
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+  name: "flutter_jailbreak_detection_plus",
+  platforms: [
+    .iOS("11.0")
+  ],
+  products: [
+    .library(name: "flutter-jailbreak-detection-plus", targets: ["flutter_jailbreak_detection_plus"])
+  ],
+  dependencies: [
+    .package(url: "https://github.com/securing/IOSSecuritySuite.git", from: "2.2.0")
+  ],
+  targets: [
+    .target(
+      name: "flutter_jailbreak_detection_plus",
+      dependencies: [
+        .product(name: "IOSSecuritySuite", package: "IOSSecuritySuite")
+      ]
+    )
+  ]
+)

--- a/ios/flutter_jailbreak_detection_plus/Sources/flutter_jailbreak_detection_plus/FlutterJailbreakDetectionPlugin.swift
+++ b/ios/flutter_jailbreak_detection_plus/Sources/flutter_jailbreak_detection_plus/FlutterJailbreakDetectionPlugin.swift
@@ -1,0 +1,22 @@
+import Flutter
+import IOSSecuritySuite
+import UIKit
+
+public class FlutterJailbreakDetectionPlugin: NSObject, FlutterPlugin {
+  public static func register(with registrar: FlutterPluginRegistrar) {
+    let channel = FlutterMethodChannel(name: "flutter_jailbreak_detection", binaryMessenger: registrar.messenger())
+    let instance = FlutterJailbreakDetectionPlugin()
+    registrar.addMethodCallDelegate(instance, channel: channel)
+  }
+
+  public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    switch call.method {
+    case "jailbroken":
+      result(IOSSecuritySuite.amIJailbroken())
+    case "developerMode":
+      result(IOSSecuritySuite.amIRunInEmulator())
+    default:
+      result(FlutterMethodNotImplemented)
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds Swift Package Manager support for the iOS implementation.

This keeps the existing CocoaPods integration unchanged and adds the Flutter SPM package layout under `ios/flutter_jailbreak_detection_plus`.

## Changes

- Add `ios/flutter_jailbreak_detection_plus/Package.swift`.
- Add an SPM source target that registers the existing `flutter_jailbreak_detection` method channel.
- Depend on `IOSSecuritySuite` through SwiftPM, starting from `2.2.0`.
- Ignore local SwiftPM build directories.

## Compatibility

- Dart API is unchanged.
- Android is unchanged.
- CocoaPods files are unchanged.
- The SPM path uses iOS 11.0 because `IOSSecuritySuite`'s Swift package declares iOS 11 support. The existing podspec remains at iOS 10.0.

## Validation

- `swift package dump-package` from `ios/flutter_jailbreak_detection_plus`: passed.
- `flutter pub get`: passed for root and example.
- `dart analyze --no-fatal-warnings`: completed with the existing `example/pubspec.yaml` deprecated `author` warning.
- `flutter build ios --simulator` with `flutter config --no-enable-swift-package-manager`: passed.
- `pod lib lint ios/flutter_jailbreak_detection_plus.podspec --configuration=Debug --skip-tests --use-modular-headers --allow-warnings`: passed.
- `pod lib lint ios/flutter_jailbreak_detection_plus.podspec --configuration=Debug --skip-tests --use-modular-headers --use-libraries --allow-warnings`: passed.
- `flutter build ios --simulator` with `flutter config --enable-swift-package-manager`: passed.

## Notes

- `flutter test` at the package root currently fails because there is no root `test/` directory.
- `flutter test` in `example/` currently fails because the existing widget test expects `Running on:` text, while the current example UI renders `Jailbroken:` and `Developer mode:`.
- `flutter pub publish --dry-run` was attempted and exits non-zero because of pre-existing checked-in files ignored by `.gitignore`; the dry-run archive includes the new SPM package files.
